### PR TITLE
테이블명 변경: `user_account` → `admin_account`

### DIFF
--- a/src/main/java/com/fastcampus/boardadminproject/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/boardadminproject/domain/AdminAccount.java
@@ -1,0 +1,84 @@
+package com.fastcampus.boardadminproject.domain;
+
+import com.fastcampus.boardadminproject.domain.constant.*;
+import com.fastcampus.boardadminproject.domain.converter.*;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import javax.persistence.*;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class AdminAccount extends AuditingFields {
+    @Id
+    @Column(length = 50)
+    private String userId;
+
+    @Setter @Column(nullable = false) private String userPassword;
+
+    @Convert(converter = RoleTypesConverter.class)
+    @Column(nullable = false)
+    private Set<RoleType> roleTypes = new LinkedHashSet<>();
+
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+
+    protected AdminAccount() {}
+
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.roleTypes = roleTypes;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+        this.createdBy = createdBy;
+        this.modifiedBy = createdBy;
+    }
+
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    }
+
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    }
+
+    public void addRoleType(RoleType roleType) {
+        this.getRoleTypes().add(roleType);
+    }
+
+    public void addRoleTypes(Collection<RoleType> roleTypes) {
+        this.getRoleTypes().addAll(roleTypes);
+    }
+
+    public void removeRoleType(RoleType roleType) {
+        this.getRoleTypes().remove(roleType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AdminAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getUserId());
+    }
+}

--- a/src/main/java/com/fastcampus/boardadminproject/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/boardadminproject/dto/AdminAccountDto.java
@@ -1,0 +1,55 @@
+package com.fastcampus.boardadminproject.dto;
+
+import com.fastcampus.boardadminproject.domain.AdminAccount;
+import com.fastcampus.boardadminproject.domain.constant.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/boardadminproject/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/boardadminproject/dto/UserAccountDto.java
@@ -1,17 +1,12 @@
 package com.fastcampus.boardadminproject.dto;
 
-import com.fastcampus.boardadminproject.domain.UserAccount;
-import com.fastcampus.boardadminproject.domain.constant.RoleType;
+import com.fastcampus.boardadminproject.domain.constant.*;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
-/**
- * A DTO for the {@link com.fastcampus.boardadminproject.domain.UserAccount} entity
- */
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -21,37 +16,12 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
-    }
-
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 }

--- a/src/main/java/com/fastcampus/boardadminproject/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/boardadminproject/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.boardadminproject.dto.security;
 
-import com.fastcampus.boardadminproject.dto.UserAccountDto;
-import com.fastcampus.boardadminproject.domain.constant.RoleType;
+import com.fastcampus.boardadminproject.domain.constant.*;
+import com.fastcampus.boardadminproject.dto.AdminAccountDto;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -42,7 +42,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -53,8 +53,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/boardadminproject/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/boardadminproject/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.boardadminproject.repository;
+
+import com.fastcampus.boardadminproject.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/fastcampus/boardadminproject/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/boardadminproject/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.fastcampus.boardadminproject.repository;
-
-import com.fastcampus.boardadminproject.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by,
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by,
                           modified_at, modified_by)
 values ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
        ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),

--- a/src/test/java/com/fastcampus/boardadminproject/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/boardadminproject/controller/ArticleManagementControllerTest.java
@@ -105,7 +105,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/boardadminproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/boardadminproject/repository/JpaRepositoryTest.java
@@ -1,7 +1,8 @@
 package com.fastcampus.boardadminproject.repository;
 
-import com.fastcampus.boardadminproject.domain.UserAccount;
-import com.fastcampus.boardadminproject.domain.constant.RoleType;
+import com.fastcampus.boardadminproject.domain.AdminAccount;
+import com.fastcampus.boardadminproject.domain.constant.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,72 +21,72 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.util.DateUtil.*;
 
 @DisplayName("JPA 연결 테스트")
-@Import(UserAccountRepositoryTest.TestJpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
-class UserAccountRepositoryTest {
-    private final UserAccountRepository userAccountRepository;
+class JpaRepositoryTest {
+    private final AdminAccountRepository adminAccountRepository;
 
-    UserAccountRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
     @Test
-    void givenUserAccounts_whenSelecting_thenWorksFine() {
+    void givenAdminAccounts_whenSelecting_thenWorksFine() {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
 
     @DisplayName("회원 정보 insert 테스트")
     @Test
-    void givenUserAccount_whenInserting_thenWorksFine() {
+    void givenAdminAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null, String.valueOf(now()));
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null, String.valueOf(now()));
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("회원 정보 update 테스트")
     @Test
-    void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
+    void givenAdminAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.MANAGER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.MANAGER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updatedUserAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAdminAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
-        assertThat(updatedUserAccount)
+        assertThat(updatedAdminAccount)
                 .hasFieldOrPropertyWithValue("userId", "uno")
                 .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.USER, RoleType.MANAGER, RoleType.DEVELOPER));
     }
 
     @DisplayName("회원 정보 delete 테스트")
     @Test
-    void givenUserAccount_whenDeleting_thenWorksFine() {
+    void givenAdminAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
+        long previousCount = adminAccountRepository.count();
 
         // When
-        userAccountRepository.deleteById("uno");
+        adminAccountRepository.deleteById("uno");
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount - 1);
     }
 
     @EnableJpaAuditing


### PR DESCRIPTION
이 PR은 기존의 어드민 회원 테이블명을 변경한다.


This closes #37 